### PR TITLE
Don't check params if they're None

### DIFF
--- a/scripts/hotshot_xl.py
+++ b/scripts/hotshot_xl.py
@@ -46,7 +46,7 @@ class HotshotXLScript(scripts.Script):
             return
 
         if isinstance(params, dict): params = HotshotXLParams(**params)
-        if params.enable:
+        if params is not None and params.enable:
             params.set_p(p)
 
             # we don't cache the conditioning because we modify it using
@@ -77,7 +77,7 @@ class HotshotXLScript(scripts.Script):
             self, p: StableDiffusionProcessing, params: Union[Dict, HotshotXLParams], **kwargs
     ):
         if isinstance(params, dict): params = HotshotXLParams(**params)
-        if params.enable and isinstance(p, StableDiffusionProcessingImg2Img):
+        if params is not None and params.enable and isinstance(p, StableDiffusionProcessingImg2Img):
             # - not supported
             ...
 
@@ -85,7 +85,7 @@ class HotshotXLScript(scripts.Script):
             self, p: StableDiffusionProcessing, res: Processed, params: Union[Dict, HotshotXLParams]
     ):
         if isinstance(params, dict): params = HotshotXLParams(**params)
-        if params.enable:
+        if params is not None and params.enable:
             model_controller.restore(shared.sd_model)
             HotshotXLOutput().output(p, res, params)
 


### PR DESCRIPTION
In some cases, especially when the user has not interacted with the GUI element yet it looks like the parameter params can be None, which leads to it not being converted to a HotshotXLParams instance. In these cases we can be pretty sure that the module is disabled, so we handle it the same way as if params.enable is False.

This does not seem to interrupt image generation, but prints a stacktrace on the console each time an image is generated.

---
Heyjo, first time I do something automatic1111/plugin code related. Saw this popping up whenever I was generating a picture and was not using the HotshotXL plugin, so I thought maybe this would be a quick fix.